### PR TITLE
Fix tuple assignment issue in bot notification time

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -67,7 +67,7 @@ class KindPredictionsBot:
                 Handles inline requests by returning a random percentage
                     to fun question "Насколько ты булка?".
         """
-    notifying_time = time(hour=10),
+    notifying_time = time(hour=10)
     notifying_days = (0, 1, 2, 3, 4, 5, 6)
 
     def __init__(


### PR DESCRIPTION
Corrected the way `notifying_time` is assigned to remove the unintended tuple. This ensures the bot sets the notification time correctly without any type errors.